### PR TITLE
 Fix Material Upload Controller: Cloudinary Config + Streaming Upload

### DIFF
--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -26,6 +26,7 @@
         "multer": "^2.0.2",
         "node-cron": "^4.2.1",
         "nodemailer": "^6.9.9",
+        "streamifier": "^0.1.1",
         "xss-clean": "^0.1.4"
       },
       "devDependencies": {
@@ -1660,6 +1661,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamifier": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+      "integrity": "sha512-zDgl+muIlWzXNsXeyUfOk9dChMjlpkq0DRsxujtYPgyJ676yQ8jEm6zzaaWHFDg5BNcLuif0eD2MTyJdZqXpdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/streamsearch": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -29,6 +29,7 @@
     "multer": "^2.0.2",
     "node-cron": "^4.2.1",
     "nodemailer": "^6.9.9",
+    "streamifier": "^0.1.1",
     "xss-clean": "^0.1.4"
   },
   "devDependencies": {

--- a/Server/routes/materialRoutes.js
+++ b/Server/routes/materialRoutes.js
@@ -9,7 +9,7 @@ import {
 } from '../controllers/materialController.js';
 
 import { protect, authorize } from '../middleware/authMiddleware.js';
-import upload from '../middleware/multerMiddleware.js';
+import { fileUpload } from '../middleware/fileUpload.js'; // ✅ Correct import
 
 const router = express.Router();
 
@@ -22,7 +22,7 @@ router.post(
   '/',
   protect,
   authorize('teacher'),
-  upload.single('file'), // ✅ Multer middleware for file upload
+  fileUpload, // ✅ Use express-fileupload middleware
   uploadMaterial
 );
 


### PR DESCRIPTION
🔧 Fix Material Upload Controller: Cloudinary Config + Streaming Upload

- Replaced incorrect cloudinary import path with proper config import from `/config/cloudinary.js`
- Added `streamifier` to handle memory-based file uploads
- Used `cloudinary.uploader.upload_stream()` for efficient in-memory uploads
- Ensured `configureCloudinary()` is called before upload
- Cleaned up error handling and added developer comments
